### PR TITLE
fix(geom): fix Rectangle#setSize with dest

### DIFF
--- a/joml-geometry/src/main/java/org/terasology/joml/geom/Rectangled.java
+++ b/joml-geometry/src/main/java/org/terasology/joml/geom/Rectangled.java
@@ -128,6 +128,8 @@ public class Rectangled implements Externalizable, Rectangledc {
 
     @Override
     public Rectangled setSize(double dx, double dy, Rectangled dest) {
+        dest.minX = this.minX;
+        dest.minY = this.minY;
         dest.maxX = dest.minX + dx;
         dest.maxY = dest.minY + dy;
         return dest;

--- a/joml-geometry/src/main/java/org/terasology/joml/geom/Rectanglef.java
+++ b/joml-geometry/src/main/java/org/terasology/joml/geom/Rectanglef.java
@@ -217,6 +217,8 @@ public class Rectanglef implements Externalizable, Rectanglefc {
 
     @Override
     public Rectanglef setSize(float dx, float dy, Rectanglef dest) {
+        dest.minX = this.minX;
+        dest.minY = this.minY;
         dest.maxX = dest.minX + dx;
         dest.maxY = dest.minY + dy;
         return dest;

--- a/joml-geometry/src/test/java/org/terasology/joml/geom/RectangledTest.java
+++ b/joml-geometry/src/test/java/org/terasology/joml/geom/RectangledTest.java
@@ -57,5 +57,14 @@ public class RectangledTest {
     public void testZeroSizeRectangle() {
         Rectangled rect = new Rectangled(0, 0, 0, 0);
         assertFalse(rect.isValid());
+        assertFalse(rect.containsPoint(new Vector2d(0,0)));
+    }
+
+    @Test
+    public void testSetSize() {
+        Rectangled rect = new Rectangled(1, 1, 2, 3);
+        Rectangled expected = new Rectangled(1, 1, 6, 6);
+        assertEquals(expected, rect.setSize(5,5, new Rectangled()));
+        assertEquals(expected, new Rectangled(rect).setSize(5, 5));
     }
 }

--- a/joml-geometry/src/test/java/org/terasology/joml/geom/RectanglefTest.java
+++ b/joml-geometry/src/test/java/org/terasology/joml/geom/RectanglefTest.java
@@ -59,5 +59,12 @@ public class RectanglefTest {
     public void testZeroSizeRectangle() {
         Rectanglef rect = new Rectanglef(0, 0, 0, 0);
         assertFalse(rect.isValid());
+        assertFalse(rect.containsPoint(new Vector2f(0,0)));
+    }
+
+    @Test
+    public void testSetSize() {
+        Rectanglef rect = new Rectanglef(1, 1, 2, 3);
+        assertEquals(new Rectanglef(rect).setSize(5, 5), rect.setSize(5,5, new Rectanglef()));
     }
 }


### PR DESCRIPTION
I spotted this too late in https://github.com/MovingBlocks/joml-ext/commit/dfb32b198af829dc2d0ab61495b48cb979c418eb#r46396777. This is actually the same issue that we had with `BlockRegion` before when implementing the variants with explicit `dest`.