### PR TITLE
feat(geom): add `Rectangle#distanceSquared(point)`

### DIFF
--- a/joml-geometry/src/main/java/org/terasology/joml/geom/Rectangledc.java
+++ b/joml-geometry/src/main/java/org/terasology/joml/geom/Rectangledc.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.joml.geom;
 
+import org.joml.Math;
 import org.joml.Vector2d;
 import org.joml.Vector2dc;
 import org.joml.Vector2fc;
@@ -360,4 +361,35 @@ public interface Rectangledc {
      */
     Rectangled intersection(Rectangleic other, Rectangled dest);
 
+    /**
+     * Computes the squared distance to a given point
+     * @param point the point
+     * @return the squared distance between point and this rectangle
+     */
+    default double distanceSquared(Vector2dc point) {
+        return distanceSquared(point.x(), point.y());
+    }
+
+    /**
+     * Computes the squared distance to a given point
+     * @param px the point x coordinate
+     * @param py the point y coordinate
+     * @return the squared distance between point and this rectangle
+     * @see
+     * <a href="https://codereview.stackexchange.com/questions/175566/compute-shortest-distance-between-point-and-a-rectangle">
+     *         Compute Shortest Distance Between Point and a Rectangle</a>
+     */
+    default double distanceSquared(double px, double py) {
+        //     center = min + width / 2 = min + (max - min) / 2
+        // 2 * center = 2 * min + max - min = min + max
+        double cx2 = minX() + maxX();
+        double cy2 = minY() + maxY();
+
+        //     dx = p - center - width / 2
+        // 2 * dx = 2 * px - 2 * center - width
+        //     dx = (2 * px - 2 * center - width) / 2
+        double dx = Math.max(Math.abs(2 * px - cx2) - getSizeX(), 0) / 2d;
+        double dy = Math.max(Math.abs(2 * py - cy2) - getSizeY(), 0) / 2d;
+        return dx * dx + dy * dy;
+    }
 }

--- a/joml-geometry/src/main/java/org/terasology/joml/geom/Rectanglefc.java
+++ b/joml-geometry/src/main/java/org/terasology/joml/geom/Rectanglefc.java
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.joml.geom;
 
+import org.joml.Math;
 import org.joml.Vector2dc;
 import org.joml.Vector2f;
 import org.joml.Vector2fc;
 import org.joml.Vector2ic;
+import org.joml.Vector3f;
+import org.joml.Vector3i;
 
 public interface Rectanglefc {
 
@@ -334,6 +337,35 @@ public interface Rectanglefc {
      */
     Rectanglef intersection(Rectanglei other, Rectanglef dest);
 
+    /**
+     * Computes the squared distance to a given point
+     * @param point the point
+     * @return the squared distance between point and this rectangle
+     */
+    default float distanceSquared(Vector2fc point) {
+        return distanceSquared(point.x(), point.y());
+    }
 
+    /**
+     * Computes the squared distance to a given point
+     * @param px the point x coordinate
+     * @param py the point y coordinate
+     * @return the squared distance between point and this rectangle
+     * @see
+     * <a href="https://codereview.stackexchange.com/questions/175566/compute-shortest-distance-between-point-and-a-rectangle">
+     *         Compute Shortest Distance Between Point and a Rectangle</a>
+     */
+    default float distanceSquared(float px, float py) {
+        //     center = min + width / 2 = min + (max - min) / 2
+        // 2 * center = 2 * min + max - min = min + max
+        float cx2 = minX() + maxX();
+        float cy2 = minY() + maxY();
 
+        //     dx = p - center - width / 2
+        // 2 * dx = 2 * px - 2 * center - width
+        //     dx = (2 * px - 2 * center - width) / 2
+        float dx = Math.max(Math.abs(2 * px - cx2) - getSizeX(), 0) / 2f;
+        float dy = Math.max(Math.abs(2 * py - cy2) - getSizeY(), 0) / 2f;
+        return dx * dx + dy * dy;
+    }
 }

--- a/joml-geometry/src/main/java/org/terasology/joml/geom/Rectangleic.java
+++ b/joml-geometry/src/main/java/org/terasology/joml/geom/Rectangleic.java
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.joml.geom;
 
+import org.joml.Math;
+import org.joml.Vector2dc;
 import org.joml.Vector2fc;
 import org.joml.Vector2i;
 import org.joml.Vector2ic;
@@ -325,6 +327,37 @@ public interface Rectangleic {
      */
     Rectanglei scale(int sx, int sy, Vector2ic anchor, Rectanglei dest);
 
+    /**
+     * Computes the squared distance to a given point
+     * @param point the point
+     * @return the squared distance between point and this rectangle
+     */
+    default long distanceSquared(Vector2ic point) {
+        return distanceSquared(point.x(), point.y());
+    }
 
+    /**
+     * Computes the squared distance to a given point
+     *
+     * @param px the point x coordinate
+     * @param py the point y coordinate
+     * @return the squared distance between point and this rectangle
+     * @see
+     * <a href="https://codereview.stackexchange.com/questions/175566/compute-shortest-distance-between-point-and-a-rectangle">
+     *         Compute Shortest Distance Between Point and a Rectangle</a>
+     */
+    default long distanceSquared(int px, int py) {
+        //     center = min + width / 2 = min + (max - min) / 2
+        // 2 * center = 2 * min + max - min = min + max
+        int cx2 = minX() + maxX();
+        int cy2 = minY() + maxY();
+
+        //     dx = p - center - width / 2
+        // 2 * dx = 2 * px - 2 * center - width
+        //     dx = (2 * px - 2 * center - width) / 2
+        long dx = Math.max(Math.abs(2 * px - cx2) - getSizeX(), 0) / 2;
+        long dy = Math.max(Math.abs(2 * py - cy2) - getSizeY(), 0) / 2;
+        return dx * dx + dy * dy;
+    }
 
 }


### PR DESCRIPTION
Based on the old implementation and [this StackExchange post](https://codereview.stackexchange.com/questions/175566/compute-shortest-distance-between-point-and-a-rectangle).

Fixes #2
