### PR TITLE
chore: replace jcenter with mavenCentral

### DIFF
--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -7,7 +7,7 @@ java {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // Extra details provided for unit tests


### PR DESCRIPTION
Locally building with `./gradlew build --no-build-cache --refresh-dependencies` succeeded.
Adds to https://github.com/MovingBlocks/Terasology/issues/4582