### PR TITLE
feat: add 'getMin'/'getMax' to Rectangled/f/i

### DIFF
--- a/joml-geometry/src/main/java/org/terasology/joml/geom/Rectangledc.java
+++ b/joml-geometry/src/main/java/org/terasology/joml/geom/Rectangledc.java
@@ -14,9 +14,29 @@ public interface Rectangledc {
 
     double minY();
 
+    /**
+     * Return the minimum corner of this rectangle.
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    default Vector2d getMin(Vector2d dest) {
+        return dest.set(minX(), minY());
+    }
+
     double maxX();
 
     double maxY();
+
+    /**
+     * Return the maximum corner of this rectangle.
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    default Vector2d getMax(Vector2d dest) {
+        return dest.set(maxX(), maxY());
+    }
 
     /**
      * Return the length of the rectangle in the X dimension.

--- a/joml-geometry/src/main/java/org/terasology/joml/geom/Rectanglefc.java
+++ b/joml-geometry/src/main/java/org/terasology/joml/geom/Rectanglefc.java
@@ -3,6 +3,7 @@
 package org.terasology.joml.geom;
 
 import org.joml.Math;
+import org.joml.Vector2d;
 import org.joml.Vector2dc;
 import org.joml.Vector2f;
 import org.joml.Vector2fc;
@@ -14,9 +15,29 @@ public interface Rectanglefc {
 
     float minY();
 
+    /**
+     * Return the minimum corner of this rectangle.
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    default Vector2f getMin(Vector2f dest) {
+        return dest.set(minX(), minY());
+    }
+
     float maxX();
 
     float maxY();
+
+    /**
+     * Return the maximum corner of this rectangle.
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    default Vector2f getMax(Vector2f dest) {
+        return dest.set(maxX(), maxY());
+    }
 
     /**
      * Return the length of the rectangle in the X dimension.

--- a/joml-geometry/src/main/java/org/terasology/joml/geom/Rectangleic.java
+++ b/joml-geometry/src/main/java/org/terasology/joml/geom/Rectangleic.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.joml.geom;
 
+import org.joml.Vector2d;
 import org.joml.Vector2dc;
 import org.joml.Vector2fc;
 import org.joml.Vector2i;
@@ -13,9 +14,29 @@ public interface Rectangleic {
 
     int minY();
 
+    /**
+     * Return the minimum corner of this rectangle.
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    default Vector2i getMin(Vector2i dest) {
+        return dest.set(minX(), minY());
+    }
+
     int maxX();
 
     int maxY();
+
+    /**
+     * Return the maximum corner of this rectangle.
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    default Vector2i getMax(Vector2i dest) {
+        return dest.set(maxX(), maxY());
+    }
 
     /**
      * Return the length of the rectangle in the X dimension.


### PR DESCRIPTION
This PR adds two missing getters to retrieve the min and max corners of the rectangle as `Vector2i/f/d`. 

Extracted from #23.
